### PR TITLE
Unrecognized flags

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -33,6 +33,9 @@ pub fn main() !void {
             std.debug.print("flag based arg missing\n", .{});
             return;
         },
+        error.UnrecognizedFlag => {
+            std.debug.print("an unrecognized flag was given\n", .{});
+        },
         else => {
             return;
         },

--- a/src/root.zig
+++ b/src/root.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const testing = std.testing;
 
 /// error set for parsing command line args
-pub const ArgParsingError = error{FlagBasedArgMissing};
+pub const ArgParsingError = error{FlagBasedArgMissing,UnrecognizedFlag};
 
 /// captures non-positional flag-based parameters and options
 pub const params: type = struct {
@@ -96,12 +96,12 @@ pub const argManager = struct {
             // also build a reference array of flags once here and use
             // to match below
 
-            for (argv, 0..) |value, i| {
+           mainArgLoop: for (argv, 0..) |value, i| {
                 if (i == 0) {
                     continue;
                 }
 
-                const inputItem = std.mem.span(value);
+                const inputItem: [:0]u8 = std.mem.span(value);
 
                 if (moreArgsToParse) {
 
@@ -140,13 +140,13 @@ pub const argManager = struct {
                                     //std.debug.print("and found that {?s} is {?any}\n", .{ sf, param.isPresent });
                                     if (param.hasArg.? == true) {
                                         self.paramArgToAdd = argi;
-                                        continue;
+                                        // continue;
                                     }
-                                    continue;
+                                    continue: mainArgLoop;
                                 }
                             }
                         }
-                        continue;
+                        return ArgParsingError.UnrecognizedFlag;
                     }
 
                     if (std.mem.startsWith(u8, inputItem, "-")) {
@@ -161,14 +161,14 @@ pub const argManager = struct {
                                     //std.debug.print("and found that {?s} is {?any}\n", .{ sf, param.isPresent });
                                     if (param.hasArg.? == true) {
                                         self.paramArgToAdd = argi;
-                                        continue;
+                                        // continue;
                                     }
-                                    continue;
+                                    continue: mainArgLoop;
                                 }
                             }
                         }
-
-                        continue;
+                        return ArgParsingError.UnrecognizedFlag;
+                        // continue;
                     }
                 }
                 // if this point is reached, then, in theory, all of the flags should be parsed.


### PR DESCRIPTION
added a default failure on unrecognized flags, but still need to decide whether to print out the problematic flag in question before returning the error (since Zig doesn’t allow multiple return values).

this runs into the tension of providing functionality out of the box but also taking away flexibility and freedom from developers...